### PR TITLE
Stream API Testing, Study API test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "verbose": true,
     "testPathIgnorePatterns": [
       "minors.test.ts",
-      "bot.test.ts",
-      "study.test.ts"
+      "bot.test.ts"
     ]
   },
   "prettier": {

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -1,5 +1,5 @@
 export class Account {
-  constructor(private readonly fetcher: Function) {}
+  constructor(private readonly fetcher: Function, private readonly streamer: Function) {}
 
   public profile() {
     return this.fetcher(`/account`)
@@ -28,8 +28,7 @@ export class Account {
     return this.fetcher(`/account/playing?nb=${limit}`)
   }
 
-  // TODO: NDJSON
-  // public following() {
-  //   return this.fetcher(`/rel/following`)
-  // }
+  public following() {
+      return this.streamer(`/rel/following`)
+  }
 }

--- a/src/api/board.ts
+++ b/src/api/board.ts
@@ -1,8 +1,8 @@
 export class Board {
-  constructor(private readonly fetcher: Function) {}
+  constructor(private readonly fetcher: Function, private readonly streamer: Function) {}
 
   public events() {
-    return this.fetcher(`/stream/event`)
+    return this.streamer(`/stream/event`)
   }
 
   // TODO: seek()
@@ -50,7 +50,7 @@ export class Board {
   // }
 
   public stream({ gameId }: { gameId: string }) {
-    return this.fetcher(`/board/game/stream/${gameId}`)
+    return this.streamer(`/board/game/stream/${gameId}`)
   }
 
   public move({ gameId, move }: { gameId: string; move: string }) {

--- a/src/api/bot.ts
+++ b/src/api/bot.ts
@@ -1,5 +1,5 @@
 export class Bot {
-  constructor(private readonly fetcher: Function) {}
+  constructor(private readonly fetcher: Function, private readonly streamer: Function) {}
 
   public online({ nb }: { nb?: number } = {}) {
     return this.fetcher(`/bot/online?nb=${nb}`)
@@ -10,7 +10,7 @@ export class Bot {
   }
 
   public stream({ gameId }: { gameId: string }) {
-    return this.fetcher(`/bot/game/stream/${gameId}`)
+    return this.streamer(`/bot/game/stream/${gameId}`)
   }
 
   public move({ gameId, move }: { gameId: string; move: string }) {

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -50,7 +50,7 @@ export class Users {
 }
 
 export class User {
-  constructor(private readonly fetcher: Function) {}
+  constructor(private readonly fetcher: Function, private readonly streamer: Function) {}
 
   public info({ username }: { username: string }) {
     return this.fetcher(`/user/${username}`)
@@ -97,8 +97,7 @@ export class User {
     return this.fetcher(`/rel/unfollow/${username}`, 'post')
   }
 
-  public studies({ username }: { username: string }) {
-    // TODO: replace with stream API
-    return this.fetcher(`/study/by/${username}`)
+  public async studies({ username }: { username: string }) {
+    return this.streamer(`/study/by/${username}`)
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,10 +5,11 @@ import { Challenge } from './api/challenge'
 import { Users, User } from './api/users'
 import { Study } from './api/study'
 // import { Analysis, Simuls, TV } from './minors'
-import { fetcher } from './utils'
+import { fetcher, streamer } from './utils'
 
 export class Equine {
   private fetcher: Function
+  private streamer: Function
 
   // v1 API
   public account: Account
@@ -33,11 +34,18 @@ export class Equine {
       body?: URLSearchParams,
     ) => fetcher({ endpoint, token: this.token, method, body })
 
+    this.streamer = async (
+        endpoint: string,
+        method?: string,
+        body?: URLSearchParams,
+        json?: boolean
+    ) => streamer({ endpoint, token: this.token, method, body, json })
+
     // v1 API
-    this.account = new Account(this.fetcher)
-    this.board = new Board(this.fetcher)
+    this.account = new Account(this.fetcher, this.streamer)
+    this.board = new Board(this.fetcher, this.streamer)
     this.challenge = new Challenge(this.fetcher)
-    this.user = new User(this.fetcher)
+    this.user = new User(this.fetcher, this.streamer)
     this.users = new Users(this.fetcher)
     this.study = new Study(this.fetcher)
 
@@ -47,6 +55,6 @@ export class Equine {
     // // this.message = new Message(this.fetcher)
     // this.simuls = new Simuls(this.fetcher)
     // this.tv = new TV(this.fetcher)
-    // this.bot = new Bot(this.fetcher)
+    // this.bot = new Bot(this.fetcher, this.streamer)
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -32,7 +32,8 @@ export class Equine {
       endpoint: string,
       method?: string,
       body?: URLSearchParams,
-    ) => fetcher({ endpoint, token: this.token, method, body })
+      json?: boolean
+    ) => fetcher({ endpoint, token: this.token, method, body, json })
 
     this.streamer = async (
         endpoint: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,29 +1,129 @@
 import { LICHESS_API_URL } from './constants'
 
-export async function fetcher({
-  endpoint,
-  token,
-  method = 'GET',
-  body,
-}: {
-  endpoint: string
-  token: string
-  method?: string
-  body?: URLSearchParams
-}) {
-  try {
-    const fetchOptions = {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      method,
-      body,
-    }
-    const response = await fetch(`${LICHESS_API_URL}${endpoint}`, fetchOptions)
-    const data = await response.json()
+/// Processes a text-decoded stream and tries to parse it into JSON.
+export class JSONStream extends TransformStream {
+    constructor() {
+        super({
+            start() {},
+            flush() {},
+            async transform(chunk: string, controller: TransformStreamDefaultController) {
+                if (chunk.trim() === '') {
+                    controller.enqueue({})
+                } else {
+                    let parsed
+                    try {
+                        parsed = JSON.parse(chunk)
+                    } catch (e) {
+                        controller.error(`Error parsing JSON: ${e}`)
+                        parsed = chunk
+                    }
 
-    return data
-  } catch (error) {
-    throw error
-  }
+                    controller.enqueue(parsed)
+                }
+            }
+        })
+    }
+}
+
+/// LichessStream is responsible for handling all lichess API stream formats.
+// export class LichessStream extends TransformStream {
+//     constructor({ json = true }: { json?: boolean }) {
+//         super({
+//             start() {},
+//             async transform(chunk: Uint8Array, controller: TransformStreamDefaultController) {
+//                 // chunk = await chunk;
+//                 let decoded = String(chunk);
+//                 if (decoded.trim() === '') {
+//                     controller.enqueue({});
+//                 } else {
+//                     let parsed;
+//                     if (json) {
+//                         try {
+//                             parsed = JSON.parse(decoded);
+//                         } catch (e) {
+//                             controller.error(`Error parsing JSON: ${e}`);
+//                             parsed = decoded;
+//                         };
+//                     } else {
+//                         parsed = decoded;
+//                     }
+//                     controller.enqueue(parsed);
+//                 }
+//             },
+//             flush() {}
+//         });
+//     }
+// }
+
+export async function streamer({
+    endpoint,
+    token,
+    method = 'GET',
+    body,
+    json = true
+}: {
+    endpoint: string
+    token: string
+    method?: string
+    body?: URLSearchParams
+    json?: boolean
+}) {
+    return new Promise(async (resolve, reject) => {
+        const fetchOptions = {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            }, 
+            method,
+            body,
+        }
+        fetch(`${LICHESS_API_URL}${endpoint}`, fetchOptions)
+        .then(response => response.body)
+        .then(stream => {
+            if (stream == null) {
+                return reject('Endpoint is not a stream, use fetcher instead.')
+            }
+            return stream.pipeThrough(new TextDecoderStream())
+        })
+        .then(stream => {
+            if (!stream) {
+                return reject('Error decoding stream')
+            }
+            if (json) {
+                return stream.pipeThrough(new JSONStream())
+            }
+            return stream
+        })
+        .then(stream => resolve(stream))
+        .catch(e => {
+            return reject(`Error fetching API: ${e}`)
+        })
+    })
+}
+
+export async function fetcher({
+    endpoint,
+    token,
+    method = 'GET',
+        body,
+}: {
+    endpoint: string
+    token: string
+    method?: string
+    body?: URLSearchParams
+}) {
+    try {
+        const fetchOptions = {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+            method,
+            body,
+        }
+        const response = await fetch(`${LICHESS_API_URL}${endpoint}`, fetchOptions)
+        const data = await response.json()
+
+        return data
+    } catch (error) {
+        throw error
+    }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,36 +25,6 @@ export class JSONStream extends TransformStream {
     }
 }
 
-/// LichessStream is responsible for handling all lichess API stream formats.
-// export class LichessStream extends TransformStream {
-//     constructor({ json = true }: { json?: boolean }) {
-//         super({
-//             start() {},
-//             async transform(chunk: Uint8Array, controller: TransformStreamDefaultController) {
-//                 // chunk = await chunk;
-//                 let decoded = String(chunk);
-//                 if (decoded.trim() === '') {
-//                     controller.enqueue({});
-//                 } else {
-//                     let parsed;
-//                     if (json) {
-//                         try {
-//                             parsed = JSON.parse(decoded);
-//                         } catch (e) {
-//                             controller.error(`Error parsing JSON: ${e}`);
-//                             parsed = decoded;
-//                         };
-//                     } else {
-//                         parsed = decoded;
-//                     }
-//                     controller.enqueue(parsed);
-//                 }
-//             },
-//             flush() {}
-//         });
-//     }
-// }
-
 export async function streamer({
     endpoint,
     token,
@@ -104,12 +74,14 @@ export async function fetcher({
     endpoint,
     token,
     method = 'GET',
-        body,
+    body,
+    json = true
 }: {
     endpoint: string
     token: string
     method?: string
     body?: URLSearchParams
+    json?: boolean
 }) {
     try {
         const fetchOptions = {
@@ -120,9 +92,12 @@ export async function fetcher({
             body,
         }
         const response = await fetch(`${LICHESS_API_URL}${endpoint}`, fetchOptions)
-        const data = await response.json()
-
-        return data
+        if (json) {
+            const data = await response.json()
+            return data
+        } else {
+            return response
+        }
     } catch (error) {
         throw error
     }

--- a/test/study.test.ts
+++ b/test/study.test.ts
@@ -7,6 +7,7 @@ describe('study.chapter()', () => {
       chapterId: 'E9SccSB6',
     })
     expect(chapter.error).toBeUndefined()
+    expect(chapter.status).toBe(200)
   })
 })
 
@@ -14,6 +15,7 @@ describe('study.chapters()', () => {
   it('should get chapters', async () => {
     const chapters = await lichess.study.chapters({ studyId: 'KjivNw7F' })
     expect(chapters.error).toBeUndefined()
+    expect(chapters.status).toBe(200)
   })
 })
 
@@ -21,6 +23,8 @@ describe('study.studies()', () => {
   it('should get all studies via username', async () => {
     const studies = await lichess.study.studies({ username: 'Nickacide' })
     expect(studies.body).toBeDefined()
+    expect(studies.error).toBeUndefined()
+    expect(studies.status).toBe(200)
   })
 })
 
@@ -41,15 +45,16 @@ describe('study.import()', () => {
       name,
     })
     expect(chapters.status).toBe(200)
+    expect(chapters.error).toBeUndefined()
   })
 })
 
 describe('user.studies()', () => {
     it('should retrieve all studies of user', async () => {
         let studies = await lichess.user.studies({ username: 'nickacide' })
-        // console.log(studies)
+        expect(studies).toBeInstanceOf(ReadableStream)
         for await (const chunk of studies) {
-            // console.log(chunk)
+            expect(chunk.error).toBeUndefined()
         }
     })
 })

--- a/test/study.test.ts
+++ b/test/study.test.ts
@@ -43,3 +43,13 @@ describe('study.import()', () => {
     expect(chapters.status).toBe(200)
   })
 })
+
+describe('user.studies()', () => {
+    it('should retrieve all studies of user', async () => {
+        let studies = await lichess.user.studies({ username: 'nickacide' })
+        // console.log(studies)
+        for await (const chunk of studies) {
+            // console.log(chunk)
+        }
+    })
+})


### PR DESCRIPTION
This PR attempts to implement a `streamer` API to be used similarly to `fetcher`. Additionally, the Study API tests have been improved. The `streamer` has so far only been implemented for `Study`, with more coverage on its way.

The tests do not work locally for me, the errors of which are either 'Missing Scope' or 'Fetch failed'. Will try investigating the problem soon. 